### PR TITLE
🐛 Build Technitium v15 with .NET 10 SDK/runtime

### DIFF
--- a/technitium-dns/Dockerfile
+++ b/technitium-dns/Dockerfile
@@ -10,9 +10,10 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:9.3.0
 FROM ${BUILD_FROM} AS build
 
 # Version configuration
-ARG DNS_SERVER_VERSION=v15.1.0
+ARG DNS_SERVER_VERSION=v15.3.0
 ARG DNS_LIBRARY_VERSION=dns-server-${DNS_SERVER_VERSION}
-ARG DOTNET_SDK_VERSION=9.0
+# Technitium DNS Server v15+ targets .NET 10
+ARG DOTNET_SDK_VERSION=10.0
 
 # .NET environment settings
 ENV DOTNET_ROOT=/usr/share/dotnet
@@ -77,7 +78,7 @@ RUN source /etc/os-release \
 FROM ${BUILD_FROM} AS install
 
 # Configure .NET runtime environment
-ARG DOTNET_SDK_VERSION=9.0
+ARG DOTNET_SDK_VERSION=10.0
 ENV DOTNET_ROOT=/usr/share/dotnet
 ENV DOTNET_NOLOGO=1
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
Technitium DNS Server v15 targets net10.0, but the Dockerfile still installed the .NET 9 SDK and runtime. The build failed with NETSDK1045 ("The current .NET SDK does not support targeting .NET 10.0"), so no v15 release could ship — leaving users stuck on v14.3.

Bump both the build-stage SDK and install-stage runtime to 10.0, and update DNS_SERVER_VERSION to v15.3.0 to deliver the latest working V15.

Closes #31

# Pull Request

## Description

<!-- Describe the changes you've made -->

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] 📦 New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ⚡ Performance improvement

## Testing

<!-- Describe the testing you've done -->

- [ ] I have tested these changes locally
- [ ] I have added/updated unit tests
- [ ] I have tested with Home Assistant

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<!-- Add screenshots or delete this section -->

## Additional Context

<!-- Add any other context about the pull request here or delete this section -->

## Related Issues

<!-- Link related issues below. Insert the issue link or reference -->
