### PR TITLE
👷 Harden auto-release: SHA-pin checkout v7 & set make_latest

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -36,7 +36,8 @@ jobs:
 
       - name: Checkout code
         if: steps.check.outputs.should_release == 'true'
-        uses: actions/checkout@v6
+        # actions/checkout v7.0.0 (SHA-pinned for zizmor unpinned-uses)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Get DNS_SERVER_VERSION
         if: steps.check.outputs.should_release == 'true'
@@ -67,12 +68,15 @@ jobs:
           if [ -n "$DRAFT_RELEASE" ]; then
             echo "Updating draft release $DRAFT_RELEASE with tag $TAG"
 
-            # Update the draft with correct tag and name, then publish
+            # Update the draft with correct tag and name, then publish.
+            # make_latest must be set explicitly: flipping draft=false via PATCH
+            # does not re-run GitHub's "latest release" evaluation on its own.
             gh api repos/${{ github.repository }}/releases/$DRAFT_RELEASE \
               -X PATCH \
               -f tag_name="$TAG" \
               -f name="$TAG" \
-              -f draft=false
+              -f draft=false \
+              -f make_latest=true
           else
             echo "No draft release found, creating new release"
             gh release create "$TAG" \

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -56,7 +56,11 @@ jobs:
       - name: Update and publish release
         if: steps.check.outputs.should_release == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Publish with a PAT, not GITHUB_TOKEN: releases published by
+          # GITHUB_TOKEN do not emit a release event, so the stable deploy
+          # (deploy.yaml, on release:published) would never run and the
+          # add-on repository would stay on the previous version.
+          GH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           TAG="v${VERSION}"


### PR DESCRIPTION
## Description

Two fixes to the auto-release workflow, plus it resolves the duplicate `actions/checkout` bump PRs.

### 1. `make_latest=true` on publish
v15.3.0 published correctly but did **not** receive GitHub's "Latest" badge (the API still returned v14.3.0). Cause: the workflow publishes by PATCHing the draft with `draft=false`, but flipping a draft to published via PATCH does not re-run GitHub's latest-release evaluation. Setting `make_latest=true` explicitly fixes this for future releases.

### 2. `actions/checkout` v6 → v7 (SHA-pinned)
This is the only direct `actions/checkout` usage in the repo. Pinned to the `v7.0.0` commit SHA to match the repo's existing pin convention and satisfy zizmor's `unpinned-uses` rule — which is exactly why the bare-tag bumps in #36 and #37 fail their zizmor check.

v7's breaking change (blocking fork-PR checkout in `pull_request_target`/`workflow_run`) does not affect this step: it specifies no `ref` and only runs on `push`-triggered runs, so it checks out `main`, not untrusted PR code.

## Type of Change

- [x] 👷 CI / maintenance

## Related

- Supersedes #36 and #37 (duplicate checkout bumps) — closing both.