### PR TITLE
👷 Relax yamllint comment spacing for Renovate action pins

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -25,7 +25,10 @@ rules:
   comments:
     level: error
     require-starting-space: true
-    min-spaces-from-content: 2
+    # 1 space (not 2) so Renovate's SHA-pin comments ("@<sha> # v1.2.3")
+    # pass; this also matches Prettier, which normalizes inline comments
+    # to a single leading space.
+    min-spaces-from-content: 1
   comments-indentation:
     level: error
   document-end:


### PR DESCRIPTION
## Description

After enabling `helpers:pinGitHubActionDigests` (#40), Renovate opened #41 to SHA-pin the GitHub Actions. That PR **fails YAMLLint**: Renovate writes pins as `@<sha> # <version>` with a **single** space before the comment, but `.yamllint` required `min-spaces-from-content: 2`, so every pinned line trips `too few spaces before comment`.

## Fix

Set `comments.min-spaces-from-content` to **1**. This:
- Accepts Renovate's single-space pin comments (unblocks #41 and all future digest bumps).
- Matches **Prettier**, which normalizes inline comments to one leading space — so the two linters stop conflicting (previously we had to work around this with standalone comments).
- Doesn't regress: existing 2-space comments still satisfy a *minimum* of 1.

## Type of Change
- [x] 👷 CI / maintenance

## Follow-up
Once this merges, Renovate will rebase #41 and it should go green and auto-merge.