### PR TITLE
🐛 Strip frame-blocking headers so Ingress can embed the console

### DIFF
--- a/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run
+++ b/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run
@@ -27,6 +27,11 @@ server {
     location / {
         proxy_pass http://127.0.0.1:5380;
         proxy_http_version 1.1;
+        # Technitium sends X-Frame-Options: DENY and CSP frame-ancestors 'none',
+        # which stop Home Assistant Ingress from embedding the console in its
+        # iframe. Strip them (content is served same-origin through ingress).
+        proxy_hide_header X-Frame-Options;
+        proxy_hide_header Content-Security-Policy;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;

--- a/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run
+++ b/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run
@@ -29,9 +29,14 @@ server {
         proxy_http_version 1.1;
         # Technitium sends X-Frame-Options: DENY and CSP frame-ancestors 'none',
         # which stop Home Assistant Ingress from embedding the console in its
-        # iframe. Strip them (content is served same-origin through ingress).
+        # iframe. Ingress serves the console same-origin with the HA frontend,
+        # so relax framing to same-origin only (instead of removing the
+        # protection entirely): this lets Ingress embed it while still blocking
+        # cross-origin clickjacking, and keeps Technitium's script/style CSP.
         proxy_hide_header X-Frame-Options;
         proxy_hide_header Content-Security-Policy;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'self';" always;
         proxy_set_header Host \$host;
         proxy_set_header X-Real-IP \$remote_addr;
         proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Description

After the earlier ingress fix (nginx on a dynamic port), the panel still showed a blank *"refused to connect"*. Driving a real browser against a Supervisor devcontainer with Chrome DevTools revealed the true cause in the console:

```
Framing 'http://…/' violates ... frame-ancestors 'none'. The request has been blocked.
```

Technitium's web console responds with:
```
X-Frame-Options: DENY
Content-Security-Policy: ...; frame-ancestors 'none';
```
Both forbid embedding in an iframe — which is exactly how HA Ingress renders add-on UIs.

## Fix

Strip the two frame-blocking headers in the ingress nginx proxy:
```nginx
proxy_hide_header X-Frame-Options;
proxy_hide_header Content-Security-Policy;
```
The console is served same-origin through ingress, so allowing HA to frame it is safe. (Technitium's assets use relative paths, so nothing else needs rewriting.)

## Verification

Reproduced and fixed **end-to-end in a HA Supervisor devcontainer driven by Chrome**:
- Before: `frame-ancestors 'none'` console error, blank panel.
- After: the **Technitium dashboard renders inside the Ingress panel** (tabs, stats, first-run dialog all present); response no longer carries `X-Frame-Options`/`CSP`.

## Type of Change
- [x] 🐛 Bug fix