### PR TITLE
👷 Set release as latest in a separate call

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -79,9 +79,7 @@ jobs:
           TAG="v${VERSION}"
 
           # Reuse the Release Drafter draft (keeps its notes) if present,
-          # otherwise create a fresh release. make_latest must be set
-          # explicitly: flipping draft=false via PATCH does not re-run
-          # GitHub's "latest release" evaluation on its own.
+          # otherwise create a fresh release.
           DRAFT_RELEASE=$(gh api "repos/${REPO}/releases" \
             --jq '.[] | select(.draft == true) | .id' | head -1)
 
@@ -92,13 +90,17 @@ jobs:
               -f tag_name="${TAG}" \
               -f name="${TAG}" \
               -f target_commitish=main \
-              -f draft=false \
-              -f make_latest=true
+              -f draft=false
           else
             echo "No draft found, creating ${TAG}"
             gh release create "${TAG}" \
               --title "${TAG}" \
               --target main \
-              --generate-notes \
-              --latest
+              --generate-notes
           fi
+
+          # Set as latest in a SEPARATE call. GitHub does not reliably apply
+          # make_latest in the same PATCH that flips draft=false, which left
+          # a published release without the "Latest" badge (and off the
+          # add-on store's update radar). Setting it afterwards is reliable.
+          gh release edit "${TAG}" --latest


### PR DESCRIPTION
## Description

**Finding:** v2026.7.1 published correctly but did **not** get GitHub's "Latest" badge — it stayed on v2026.7.0. Because the add-on store / HA update detection keys off the latest release, this would keep users from being offered updates.

**Cause:** `auto-release.yaml` set `make_latest=true` in the *same* PATCH that flips `draft=false`. GitHub does **not** reliably apply `make_latest` in that combined draft→publish call (confirmed: a separate `gh release edit v2026.7.1 --latest` afterwards worked immediately).

## Fix

Publish first, then set "Latest" in a **separate** `gh release edit "$TAG" --latest` call — applied to both the draft-publish and fresh-create paths. The separate edit fires a `release: edited` event (not `published`), so it doesn't re-trigger the deploy.

## Already done manually
v2026.7.1 is now correctly marked **Latest** (fixed by hand); this PR prevents recurrence for all future auto-releases.

## Validation
- ✅ yamllint + prettier (repo configs) clean

## Type of Change
- [x] 👷 CI / maintenance