### PR TITLE
🔥 Remove legacy port mappings (inert under host_network)

### DIFF
--- a/technitium-dns/DOCS.md
+++ b/technitium-dns/DOCS.md
@@ -79,16 +79,18 @@ Recommended setup:
 | 443  | TCP      | DNS-over-HTTPS (HTTP/1.1 + HTTP/2) |
 | 443  | UDP      | DNS-over-HTTPS (HTTP/3)            |
 
-To change port mappings:
-
-1. Go to the add-on configuration page
-2. Scroll to "Network" section
-3. Click the port number you want to change
-4. Enter new port number (e.g., `8853` for DNS-over-TLS)
-5. Click "Save"
+> [!NOTE]
+> This add-on runs in **host network** mode, so ports are **not** mapped
+> through Home Assistant — Technitium binds directly to the host's ports.
+> There is no "Network" section on the add-on page; enable protocols and
+> change their ports in the Technitium web console under
+> **Settings → Optional Protocols**.
 
 > [!NOTE]
-> Only port 53 are enabled by default.
+> Only standard DNS on port 53 is enabled by default. Enable
+> DNS-over-TLS, DNS-over-HTTPS, and DNS-over-QUIC in the Technitium web
+> console (**Settings → Optional Protocols**), providing a TLS
+> certificate where required.
 
 ### 🏠 Local DNS Zones
 

--- a/technitium-dns/config.yaml
+++ b/technitium-dns/config.yaml
@@ -20,12 +20,3 @@ map:
   - type: addon_config
     read_only: false
 host_network: true
-ports:
-  53/tcp: null
-  53/udp: 53
-  443/tcp: null
-  443/udp: null
-  853/tcp: null
-  853/udp: null
-  5380/tcp: null
-  53443/tcp: null


### PR DESCRIPTION
## Description

The `ports:` block in `config.yaml` is a leftover from before the add-on moved to `host_network: true`. Under host networking, Technitium binds the host's ports **directly** and the HA port mapping has **no effect**.

Worse, it was actively misleading: the block rendered a **"Network"** section on the add-on page, and `DOCS.md` instructed users to *"change port mappings"* there — which does nothing. This likely contributes to confusion (e.g. #49, where a user mapped ports 1:1 expecting it to enable DoT/DoH).

## Changes
- **`config.yaml`**: remove the `ports:` block.
- **`DOCS.md`**: drop the "change port mappings via the Network section" steps; document that protocols/ports are configured in Technitium's web console (**Settings → Optional Protocols**). The informative port/protocol table stays.

## Notes
- **No functional change** — the mappings were already inert under host networking; port binding is unaffected.
- Tradeoff: the (non-functional) "Network" section no longer appears on the add-on page; the accurate port list remains in DOCS.md.

## Type of Change
- [x] 🧰 Maintenance / docs