### PR TITLE
🐛 Pass --repo to gh release commands in auto-release

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -94,6 +94,7 @@ jobs:
           else
             echo "No draft found, creating ${TAG}"
             gh release create "${TAG}" \
+              --repo "${REPO}" \
               --title "${TAG}" \
               --target main \
               --generate-notes
@@ -103,4 +104,6 @@ jobs:
           # make_latest in the same PATCH that flips draft=false, which left
           # a published release without the "Latest" badge (and off the
           # add-on store's update radar). Setting it afterwards is reliable.
-          gh release edit "${TAG}" --latest
+          # --repo is required: this job has no checkout, so gh cannot infer
+          # the repository from git context (gh api uses ${REPO} explicitly).
+          gh release edit "${TAG}" --repo "${REPO}" --latest


### PR DESCRIPTION
## Description

First real CalVer auto-release (on #50) **published `v2026.7.2` but failed to mark it "Latest"**, erroring with:

```
Publishing draft … as v2026.7.2
failed to run git: fatal: not a git repository
```

**Cause:** the CalVer rewrite (#44) removed the `actions/checkout` step (the version is computed via the API, so no checkout is needed). But `gh release edit` / `gh release create` — unlike `gh api` — fall back to inferring the repository from local **git context** when `--repo` is omitted. With no checkout, that inference fails.

The `gh api` calls were fine (they use `repos/${REPO}/…` explicitly); only the two `gh release …` commands lacked the repo.

## Fix

Pass `--repo "${REPO}"` on both `gh release edit` and `gh release create`.

## Already handled manually
`v2026.7.2` is now correctly marked **Latest** (fixed by hand), and its stable deploy ran. This PR prevents recurrence.

## Validation
- ✅ yamllint + prettier (repo configs) clean

## Type of Change
- [x] 🐛 Bug fix