### PR TITLE
✨ Log correct web console access URLs at startup

### DIFF
--- a/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/dns-server/run
+++ b/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/dns-server/run
@@ -55,6 +55,16 @@ if [ ! -f "$FIRST_RUN_MARKER" ]; then
 fi
 
 # -----------------------------------------------------------------------------
+# Web console access hint
+# -----------------------------------------------------------------------------
+# Technitium's own startup message (printed below) advertises its internal
+# container hostname, which isn't reachable from a browser. Log the correct
+# access paths first so users aren't misled by it.
+bashio::log.info "dns-server: Open the web console via the Ingress panel (sidebar / 'Open Web UI'),"
+bashio::log.info "dns-server: or directly at http://<your-home-assistant-host>:5380 (e.g. http://homeassistant.local:5380)."
+bashio::log.info "dns-server: Note: Technitium's line below shows its internal container hostname — you can ignore it."
+
+# -----------------------------------------------------------------------------
 # Launch DNS Server
 # -----------------------------------------------------------------------------
 # Start the DNS server with the .NET runtime


### PR DESCRIPTION
## Description

Follow-up to #46. Technitium prints this on startup:
```
Note: Open http://eaf59bfe-technitium-dns:5380/ in web browser to access web console.
```
That's Technitium logging its **container hostname**, which isn't reachable from a browser — it confuses users into thinking something's broken (it isn't). We can't change Technitium's own message, but we *can* log the correct access paths right before it.

## Change

Adds three `bashio::log.info` lines to the `dns-server` run script (just before launching Technitium):
```
dns-server: Open the web console via the Ingress panel (sidebar / 'Open Web UI'),
dns-server: or directly at http://<your-home-assistant-host>:5380 (e.g. http://homeassistant.local:5380).
dns-server: Note: Technitium's line below shows its internal container hostname — you can ignore it.
```

## Notes
- Purely additive logging — no functional change, no fragile log rewriting.

## Type of Change
- [x] ✨ Enhancement