### PR TITLE
🐛 Only prune untagged images so release tags survive (#61)

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -14,6 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Only untagged versions are pruned. Tagged versions (release CalVer
+      # tags plus the stable/beta/edge channel tags) MUST be preserved: the
+      # store config resolves installs via the per-arch image
+      # `ghcr.io/staerk-ha-addons/technitium-dns/{arch}:<version>`, so deleting
+      # a tagged release here 404s every install/update of that version.
+      # (This was the cause of #61 — delete-only-untagged-versions was false,
+      # so edge churn pushed release tags out of the keep window and pruned
+      # them. ignore-versions does not reliably match container tags, so it
+      # cannot be relied on as the safeguard.)
       - name: Delete old untagged versions of technitium-dns/amd64 package
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
         continue-on-error: true
@@ -21,7 +30,7 @@ jobs:
           package-name: "technitium-dns/amd64"
           package-type: container
           min-versions-to-keep: 10
-          ignore-versions: "^stable$|^beta$|^edge$|^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+          delete-only-untagged-versions: true
 
       - name: Delete old untagged versions of technitium-dns/aarch64 package
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5
@@ -30,4 +39,4 @@ jobs:
           package-name: "technitium-dns/aarch64"
           package-type: container
           min-versions-to-keep: 10
-          ignore-versions: "^stable$|^beta$|^edge$|^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+          delete-only-untagged-versions: true


### PR DESCRIPTION
## Problem

Installing/updating **Technitium DNS Server 2026.7.4** fails on all architectures with `[404] manifest unknown` (reported in #61):

```
Can't install ghcr.io/staerk-ha-addons/technitium-dns/aarch64:2026.7.4: [404] manifest unknown
```

- `ghcr.io/staerk-ha-addons/technitium-dns:2026.7.4` (multi-arch manifest) — **exists**
- `ghcr.io/staerk-ha-addons/technitium-dns/aarch64:2026.7.4` (per-arch) — **404**
- `ghcr.io/staerk-ha-addons/technitium-dns/amd64:2026.7.4` (per-arch) — **404**

## Root cause

The store config resolves installs via the **per-arch** image `ghcr.io/staerk-ha-addons/technitium-dns/{arch}:<version>`. The deploy pushes those per-arch tags *and* assembles the multi-arch manifest from them.

This weekly cleanup ran with `delete-only-untagged-versions: false` and `min-versions-to-keep: 10` on the per-arch packages. Every merge to `main` pushes an edge build, so within ~10 pushes a released per-arch tag fell out of the keep window and got **deleted** (run logs show 91 versions pruned per arch on 2026-07-12). The top-level multi-arch package is never cleaned — which is exactly why `…/technitium-dns:2026.7.4` still resolves but `…/technitium-dns/{arch}:2026.7.4` 404s.

The `ignore-versions` SemVer regex was intended to shield releases, but `actions/delete-package-versions` does not reliably match it against container **tags**, so it did not protect `2026.7.4`.

## Fix

Prune **only untagged** versions (`delete-only-untagged-versions: true`) — matching this workflow's own title, *"Clean up old untagged packages"*. Release CalVer tags and the `stable`/`beta`/`edge` channel tags are now preserved; only dangling untagged manifest layers are removed.

## Follow-up (not in this PR)

Fixing cleanup does not resurrect already-deleted tags. After merge, `2026.7.5` will be cut (via #34 / v15.4.0) to publish fresh, now-durable images and unblock installs.

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)