### PR TITLE
📝 Heal 2026.7.4 install 404 with a fresh release (#69)

### DIFF
--- a/technitium-dns/DOCS.md
+++ b/technitium-dns/DOCS.md
@@ -162,6 +162,15 @@ Zone name: 1.168.192.in-addr.arpa
    - Check DNS server logs
    - Test with `dig` or `nslookup`
 
+4. **Install or update fails with `manifest ... not found` (404)**
+   - Home Assistant pinned an image digest that has since been removed from
+     the container registry, so the pull returns a 404 even though the
+     version still exists.
+   - Updating to the latest add-on version resolves it, because Home
+     Assistant re-resolves the image and pulls a digest that exists.
+   - If no update is offered and you are stuck, take a **backup** of the
+     add-on first, then uninstall and reinstall it to force a fresh pull.
+
 ## 💡 Support
 
 Got questions?


### PR DESCRIPTION
## What & why

Fixes #69.

Affected supervisors pinned the **original** `2026.7.4` image digests (`amd64 7197…`, `aarch64 cd5557…`) from the 2026-07-11 build. The old package-cleanup workflow deleted those tagged manifests; the `2026.7.4` tag was later rebuilt/re-pushed to **new** digests (`amd64 88b0ecd9…`, `aarch64 603d59d9…`, built 2026-07-26) which resolve fine today. But because the store still advertises the same version number, pinned supervisors keep requesting the deleted digests → `manifest ... not found` 404.

`#61` stops future deletions but can't resurrect a specific deleted digest. The clean heal is a **new version number** so supervisors re-resolve the image tag and pull a digest that exists.

## Change

- Add a Troubleshooting entry in `DOCS.md` documenting the 404 cause and the backup → reinstall workaround.
- This `technitium-dns/` change flows through `auto-release.yaml`, cutting a fresh CalVer version and rebuilding/pushing images — which is what actually heals affected installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)