### PR TITLE
Fix: Update bashio::addon.ingress_port to bashio::app.ingress_port

### DIFF
--- a/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run
+++ b/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run
@@ -13,7 +13,7 @@ set -o nounset -o errexit -o pipefail
 
 # Port assigned by the Supervisor for this add-on's ingress session
 declare ingress_port
-ingress_port=$(bashio::addon.ingress_port)
+ingress_port=$(bashio::app.ingress_port)
 
 bashio::log.info "ingress: proxying port ${ingress_port} -> 127.0.0.1:5380"
 


### PR DESCRIPTION
Fixes depreciation warning: bashio::addon.ingress_port is deprecated, use bashio::app.ingress_port

# Pull Request

## Description

Updated bashio::addon.ingress_port to bashio::app.ingress_port in [technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run](https://github.com/staerk-ha-addons/addon-technitium-dns/blob/fb57d8649994f25ed344ca44f527514d39de3bf2/technitium-dns/rootfs/etc/s6-overlay/s6-rc.d/ingress/run#L16)

## Type of Change

<!-- Put an `x` in all the boxes that apply -->

- [ ] 📦 New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactoring
- [ ] ⚡ Performance improvement

## Testing

No testing; this is apart of Home Assistant's rename of addons to apps.

- [ ] I have tested these changes locally
- [ ] I have added/updated unit tests
- [ ] I have tested with Home Assistant

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published
